### PR TITLE
Add overview dashboard UI

### DIFF
--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,21 +1,39 @@
 "use client"
 
 import React from "react"
+import { StatsCard } from "@/components/stats-card"
+import { Heatmap } from "@/components/heatmap"
+import { StatusBanner } from "@/components/status-banner"
 
 export default function HomePage() {
+  const totalRecords = 123456
+  const matchRate = 86.4
+  const discrepancies = 2345
+  const avgDelta = 4.2
+
+  const flows = ["Flow A", "Flow B", "Flow C"]
+  const sites = ["Site 1", "Site 2", "Site 3"]
+  const data = [
+    [10, 20, 5],
+    [30, 40, 15],
+    [50, 60, 20],
+  ]
+
   return (
     <div className="flex flex-col w-full h-full">
       <main className="flex-1 overflow-auto p-4">
         <div className="flex flex-col gap-4">
           <h1 className="text-2xl font-bold mb-8">Dashboard</h1>
-          <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
+          <div className="grid auto-rows-min gap-4 md:grid-cols-4">
+            <StatsCard title="Enregistrements" value={totalRecords} />
+            <StatsCard title="% concordance" value={`${matchRate}%`} />
+            <StatsCard title="Discrepancies" value={discrepancies} />
+            <StatsCard title="Delta moyen" value={avgDelta} />
           </div>
-          <div className="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min" />
+          <Heatmap data={data} rows={flows} cols={sites} />
+          <StatusBanner value={100 - matchRate} />
         </div>
       </main>
     </div>
   )
-} 
+}

--- a/components/heatmap.tsx
+++ b/components/heatmap.tsx
@@ -1,0 +1,47 @@
+interface HeatmapProps {
+  data: number[][]; // percentages 0-100
+  rows: string[];
+  cols: string[];
+}
+
+export function Heatmap({ data, rows, cols }: HeatmapProps) {
+  const getColor = (value: number) => {
+    if (value > 75) return "bg-red-500";
+    if (value > 50) return "bg-orange-400";
+    if (value > 25) return "bg-yellow-300";
+    return "bg-green-400";
+  };
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-center border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2"></th>
+            {cols.map(col => (
+              <th key={col} className="p-2 text-sm font-medium">
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={row}>
+              <th className="p-2 text-sm font-medium text-left">{row}</th>
+              {cols.map((_, j) => (
+                <td key={j} className="p-1">
+                  <div
+                    className={`${getColor(data[i][j])} text-xs text-white rounded-md p-2`}
+                  >
+                    {data[i][j]}%
+                  </div>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/stats-card.tsx
+++ b/components/stats-card.tsx
@@ -1,0 +1,19 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface StatsCardProps {
+  title: string;
+  value: string | number;
+}
+
+export function StatsCard({ title, value }: StatsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <span className="text-3xl font-bold">{value}</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/status-banner.tsx
+++ b/components/status-banner.tsx
@@ -1,0 +1,22 @@
+interface StatusBannerProps {
+  value: number; // percentage
+  threshold?: number; // default 50
+}
+
+export function StatusBanner({ value, threshold = 50 }: StatusBannerProps) {
+  let color = "bg-green-500";
+  let label = "\u{1F7E2} OK"; // 🟢
+  if (value > threshold) {
+    color = "bg-red-500";
+    label = "\u{1F534} Critique"; // 🔴
+  } else if (value > threshold / 2) {
+    color = "bg-yellow-400";
+    label = "\u{1F7E0} Alerte"; // 🟠
+  }
+
+  return (
+    <div className={`${color} text-white text-center rounded-md p-4 font-bold`}>
+      {label}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `StatsCard`, `Heatmap`, and `StatusBanner` components
- show example dashboard data on overview page

## Testing
- `npx eslint . --ext .js,.jsx,.ts,.tsx` *(fails: Cannot find package `@eslint/eslintrc`)*

------
https://chatgpt.com/codex/tasks/task_e_6842de034ad4833290588a16107140fd