### PR TITLE
Improve heatmap and status banner design

### DIFF
--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -7,23 +7,26 @@ import { StatusBanner } from "@/components/status-banner"
 
 export default function HomePage() {
 
-  const flows = ["Flow A", "Flow B", "Flow C"]
-  const sites = ["Site 1", "Site 2", "Site 3"]
+  const flows = ["Flow A", "Flow B", "Flow C", "Flow D", "Flow E"]
+  const sites = ["Site 1", "Site 2", "Site 3", "Site 4"]
   const data = [
-    [10, 20, 5],
-    [30, 40, 15],
-    [50, 60, 20],
+    [95, 88, 90, 85],
+    [82, 76, 80, 70],
+    [60, 55, 58, 63],
+    [40, 35, 38, 33],
+    [20, 25, 22, 18],
   ]
+  const matchRate = 96.4
 
   return (
     <div className="flex flex-1 flex-col">
-    <div className="@container/main flex flex-1 flex-col gap-2">
-      <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-        <StatsCards />
+      <div className="@container/main flex flex-1 flex-col gap-2">
+        <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+          <StatsCards />
           <Heatmap data={data} rows={flows} cols={sites} />
           <StatusBanner value={100 - matchRate} />
-          </div>
-          </div>
         </div>
+      </div>
+    </div>
   )
 }

--- a/components/heatmap.tsx
+++ b/components/heatmap.tsx
@@ -4,44 +4,60 @@ interface HeatmapProps {
   cols: string[];
 }
 
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 export function Heatmap({ data, rows, cols }: HeatmapProps) {
   const getColor = (value: number) => {
-    if (value > 75) return "bg-red-500";
-    if (value > 50) return "bg-orange-400";
-    if (value > 25) return "bg-yellow-300";
-    return "bg-green-400";
+    if (value > 75) return "var(--chart-1)";
+    if (value > 50) return "var(--chart-2)";
+    if (value > 25) return "var(--chart-3)";
+    if (value > 10) return "var(--chart-4)";
+    return "var(--chart-5)";
   };
 
   return (
-    <div className="overflow-auto">
-      <table className="min-w-full text-center border-collapse">
-        <thead>
-          <tr>
-            <th className="p-2"></th>
-            {cols.map(col => (
-              <th key={col} className="p-2 text-sm font-medium">
-                {col}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, i) => (
-            <tr key={row}>
-              <th className="p-2 text-sm font-medium text-left">{row}</th>
-              {cols.map((_, j) => (
-                <td key={j} className="p-1">
-                  <div
-                    className={`${getColor(data[i][j])} text-xs text-white rounded-md p-2`}
-                  >
-                    {data[i][j]}%
-                  </div>
-                </td>
+    <div className="px-4 lg:px-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Concordance par flow / site</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-auto">
+          <table className="min-w-full border-collapse text-center">
+            <thead>
+              <tr>
+                <th className="p-2"></th>
+                {cols.map((col) => (
+                  <th key={col} className="p-2 text-sm font-medium">
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={row}>
+                  <th className="p-2 text-left text-sm font-medium">{row}</th>
+                  {cols.map((_, j) => (
+                    <td key={j} className="p-1">
+                      <div
+                        style={{ backgroundColor: getColor(data[i][j]) }}
+                        className="rounded-md p-2 text-xs font-medium text-card-foreground"
+                      >
+                        {data[i][j]}%
+                      </div>
+                    </td>
+                  ))}
+                </tr>
               ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/components/status-banner.tsx
+++ b/components/status-banner.tsx
@@ -3,20 +3,50 @@ interface StatusBannerProps {
   threshold?: number; // default 50
 }
 
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 export function StatusBanner({ value, threshold = 50 }: StatusBannerProps) {
-  let color = "bg-green-500";
-  let label = "\u{1F7E2} OK"; // 🟢
+  let status = {
+    color: "var(--chart-5)",
+    label: "\u{1F7E2} Stable",
+    desc: "Le système fonctionne normalement",
+  };
+
   if (value > threshold) {
-    color = "bg-red-500";
-    label = "\u{1F534} Critique"; // 🔴
+    status = {
+      color: "var(--destructive)",
+      label: "\u{1F534} Critique",
+      desc: "Trop de divergences détectées",
+    };
   } else if (value > threshold / 2) {
-    color = "bg-yellow-400";
-    label = "\u{1F7E0} Alerte"; // 🟠
+    status = {
+      color: "var(--chart-4)",
+      label: "\u{1F7E0} Alerte",
+      desc: "Des divergences nécessitent une attention",
+    };
   }
 
   return (
-    <div className={`${color} text-white text-center rounded-md p-4 font-bold`}>
-      {label}
+    <div className="px-4 lg:px-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Statut général</CardTitle>
+          <div
+            className="rounded-md px-2 py-1 text-sm font-medium"
+            style={{ backgroundColor: status.color, color: "var(--card-foreground)" }}
+          >
+            {status.label}
+          </div>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          {status.desc} ({value}% d'erreurs)
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign `Heatmap` component with Card layout and neutral colors
- improve `StatusBanner` component to display detailed status info
- align heatmap padding with stats cards and add sample data
- add more flows and sites on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f66273a483329489a2e375c6d05b