### PR TITLE
Add evolution temporelle charts

### DIFF
--- a/app/(authenticated)/evolution_temporelle/page.tsx
+++ b/app/(authenticated)/evolution_temporelle/page.tsx
@@ -1,10 +1,84 @@
-'use client';
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { SimpleLineChart } from '@/components/simple-line-chart'
 
 export default function EvolutionTemporellePage() {
+  const days = Array.from({ length: 14 }, (_, i) => i + 1)
+  const flows = ['Flow A', 'Flow B', 'Flow C']
+  const mismatchesSeries = flows.map((label, idx) => ({
+    label,
+    data: days.map(() => Math.floor(Math.random() * 20) + 5),
+  }))
+
+  const conformitySeries = [
+    {
+      label: 'Taux de conformité',
+      data: days.map(() => 80 + Math.random() * 20),
+    },
+  ]
+
+  const totals = days.map((_, i) =>
+    mismatchesSeries.reduce((sum, s) => sum + s.data[i], 0)
+  )
+  const forecastDays = 7
+  const forecastSeries = {
+    label: 'Prévision',
+    data: Array.from({ length: forecastDays }, (_, i) =>
+      Math.max(0, totals[totals.length - 1] + (i + 1) * (Math.random() * 6 - 3))
+    ),
+    dashed: true,
+  }
+  const forecastLabels = [
+    ...days,
+    ...Array.from({ length: forecastDays }, (_, i) => days.length + i + 1),
+  ]
+  const actualSeries = {
+    label: 'Mismatches',
+    data: totals,
+  }
+
   return (
-    <div>
-      <h1>Evolution temporelle Page</h1>
-      <p>This is a placeholder page.</p>
+    <div className='flex flex-col gap-4 px-4 py-4 lg:px-6'>
+      <h1 className='ml-2 mt-2 text-2xl font-bold'>Évolution temporelle</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Mismatches par jour / par flux</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SimpleLineChart series={mismatchesSeries} />
+          <div className='mt-2 flex gap-4 text-sm'>
+            {mismatchesSeries.map((s, i) => (
+              <div key={i} className='flex items-center gap-1'>
+                <span
+                  className='h-2 w-2 rounded-full'
+                  style={{ backgroundColor: `var(--chart-${i + 1})` }}
+                />
+                {s.label}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Courbe du taux de conformité rolling 7j</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SimpleLineChart series={conformitySeries} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Zone de forecasting (alertes précoces)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SimpleLineChart series={[actualSeries, forecastSeries]} />
+        </CardContent>
+      </Card>
     </div>
-  );
-} 
+  )
+}

--- a/components/simple-line-chart.tsx
+++ b/components/simple-line-chart.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils"
+
+interface LineChartSeries {
+  label: string
+  data: number[]
+  color?: string
+  dashed?: boolean
+}
+
+interface SimpleLineChartProps {
+  series: LineChartSeries[]
+  height?: number
+  className?: string
+}
+
+export function SimpleLineChart({
+  series,
+  height = 200,
+  className,
+}: SimpleLineChartProps) {
+  if (!series.length) return null
+  const all = series.flatMap((s) => s.data)
+  const max = Math.max(...all)
+  const min = Math.min(...all)
+  const range = max - min || 1
+  const len = Math.max(...series.map((s) => s.data.length))
+  const width = len - 1
+
+  const y = (v: number) => (1 - (v - min) / range) * height
+
+  const buildPath = (data: number[]) =>
+    data
+      .map((v, i) => `${i === 0 ? "M" : "L"}${i} ${y(v)}`)
+      .join(" ")
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn("w-full overflow-visible", className)}
+      preserveAspectRatio="none"
+    >
+      {series.map((s, i) => (
+        <path
+          key={i}
+          d={buildPath(s.data)}
+          fill="none"
+          stroke={s.color || `var(--chart-${i + 1})`}
+          strokeWidth={2}
+          strokeDasharray={s.dashed ? "4 2" : undefined}
+        />
+      ))}
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add simple SVG-based line chart component
- build evolution temporelle page with charts for mismatches, conformity rate and forecast

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843188f948c8332a58b0bf9518d6b90